### PR TITLE
fixes restoreBoost, fixes an error that occurs when running build-lib more than once

### DIFF
--- a/scripts/build-libc++
+++ b/scripts/build-libc++
@@ -189,7 +189,7 @@ unpackBoost()
 
 restoreBoost()
 {
-    cp $BOOST_SRC/tools/build/example/user-config.jam-bk $BOOST_SRC/tools/build/example/user-config.jam
+    mv $BOOST_SRC/tools/build/example/user-config.jam.bk $BOOST_SRC/tools/build/example/user-config.jam
 }
 
 #===============================================================================

--- a/scripts/build-libstdc++
+++ b/scripts/build-libstdc++
@@ -190,7 +190,7 @@ unpackBoost()
 
 restoreBoost()
 {
-    cp $BOOST_SRC/tools/build/example/user-config.jam-bk $BOOST_SRC/tools/build/example/user-config.jam
+    mv $BOOST_SRC/tools/build/example/user-config.jam.bk $BOOST_SRC/tools/build/example/user-config.jam
 }
 
 #===============================================================================


### PR DESCRIPTION
Yesterday I was working with build-libc++ and fixed an issue that prevents running it more than once and thought of sharing the fix with you guys.

This issue also affects build-libstdc++ so I added the fix there as well.

Thanks and keep up the good work!