### PR TITLE
Fix linker issue with utf8_codecvt_facet.cpp

### DIFF
--- a/scripts/build-libc++
+++ b/scripts/build-libc++
@@ -182,6 +182,23 @@ unpackBoost()
     [ -d $BOOST_SRC ] || ( cd $SRCDIR; tar xfj $BOOST_TARBALL )
     [ -d $BOOST_SRC ] && echo "    ...unpacked as $BOOST_SRC"
 
+    # Fix linker issue with utf8_codecvt_facet.cpp
+    # copied from http://swift.im/git/swift/tree/3rdParty/Boost/update.sh#n48?id=8dce1cd03729624a25a98dd2c0d026b93e452f86
+    echo Fixing utf8_codecvt_facet.cpp duplicates...
+
+    [ -f "$BOOST_SRC/libs/filesystem/src/utf8_codecvt_facet.cpp" ] && (mv "$BOOST_SRC/libs/filesystem/src/utf8_codecvt_facet.cpp" "$BOOST_SRC/libs/filesystem/src/filesystem_utf8_codecvt_facet.cpp" )
+    sed -i .bak 's/utf8_codecvt_facet/filesystem_utf8_codecvt_facet/' "$BOOST_SRC/libs/filesystem/build/Jamfile.v2"
+
+    [ -f "$BOOST_SRC/libs/program_options/src/utf8_codecvt_facet.cpp" ] && (mv "$BOOST_SRC/libs/program_options/src/utf8_codecvt_facet.cpp" "$BOOST_SRC/libs/program_options/src/program_options_utf8_codecvt_facet.cpp" )
+    sed -i .bak 's/utf8_codecvt_facet/program_options_utf8_codecvt_facet/' "$BOOST_SRC/libs/program_options/build/Jamfile.v2"
+
+    for lib in $BOOST_LIBS; do
+      rm -rf $BOOST_SRC/libs/$lib/*.doc $BOOST_SRC/libs/$lib/src/*.doc $BOOST_SRC/libs/$lib/test
+    done
+    rm -rf $BOOST_SRC/tools/bcp/*.html $BOOST_SRC/libs/test $BOOST_SRC/doc $BOOST_SRC/boost.png $BOOST_SRC/boost/test
+
+    echo Fixed utf8_codecvt_facet.cpp duplicates...
+
     doneSection
 }
 

--- a/scripts/build-libstdc++
+++ b/scripts/build-libstdc++
@@ -183,6 +183,23 @@ unpackBoost()
     [ -d $BOOST_SRC ] || ( cd $SRCDIR; tar xfj $BOOST_TARBALL )
     [ -d $BOOST_SRC ] && echo "    ...unpacked as $BOOST_SRC"
 
+    # Fix linker issue with utf8_codecvt_facet.cpp
+    # copied from http://swift.im/git/swift/tree/3rdParty/Boost/update.sh#n48?id=8dce1cd03729624a25a98dd2c0d026b93e452f86
+    echo Fixing utf8_codecvt_facet.cpp duplicates...
+
+    [ -f "$BOOST_SRC/libs/filesystem/src/utf8_codecvt_facet.cpp" ] && (mv "$BOOST_SRC/libs/filesystem/src/utf8_codecvt_facet.cpp" "$BOOST_SRC/libs/filesystem/src/filesystem_utf8_codecvt_facet.cpp" )
+    sed -i .bak 's/utf8_codecvt_facet/filesystem_utf8_codecvt_facet/' "$BOOST_SRC/libs/filesystem/build/Jamfile.v2"
+
+    [ -f "$BOOST_SRC/libs/program_options/src/utf8_codecvt_facet.cpp" ] && (mv "$BOOST_SRC/libs/program_options/src/utf8_codecvt_facet.cpp" "$BOOST_SRC/libs/program_options/src/program_options_utf8_codecvt_facet.cpp" )
+    sed -i .bak 's/utf8_codecvt_facet/program_options_utf8_codecvt_facet/' "$BOOST_SRC/libs/program_options/build/Jamfile.v2"
+
+    for lib in $BOOST_LIBS; do
+      rm -rf $BOOST_SRC/libs/$lib/*.doc $BOOST_SRC/libs/$lib/src/*.doc $BOOST_SRC/libs/$lib/test
+    done
+    rm -rf $BOOST_SRC/tools/bcp/*.html $BOOST_SRC/libs/test $BOOST_SRC/doc $BOOST_SRC/boost.png $BOOST_SRC/boost/test
+
+    echo Fixed utf8_codecvt_facet.cpp duplicates...
+
     doneSection
 }
 


### PR DESCRIPTION
Fixes this linker issue:

```
Undefined symbols for architecture x86_64:
  "vtable for boost::filesystem::detail::utf8_codecvt_facet", referenced from:
      (anonymous namespace)::path_locale() in libboost.a(path.o)
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
  "vtable for boost::program_options::detail::utf8_codecvt_facet", referenced from:
      __GLOBAL__sub_I_convert.cpp in libboost.a(convert.o)
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
```

copied from http://swift.im/git/swift/tree/3rdParty/Boost/update.sh#n48?id=8dce1cd03729624a25a98dd2c0d026b93e452f86
