### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#ofxiOSBoost for Boost 1.60.0  [![image](https://travis-ci.org/danoli3/ofxiOSBoost.svg?branch=master)](https://travis-ci.org/danoli3/ofxiOSBoost?branch=master)
+# ofxiOSBoost for Boost 1.60.0  [![image](https://travis-ci.org/danoli3/ofxiOSBoost.svg?branch=master)](https://travis-ci.org/danoli3/ofxiOSBoost?branch=master)
 --------------------
 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
